### PR TITLE
Update Notification.php

### DIFF
--- a/src/API/Notification.php
+++ b/src/API/Notification.php
@@ -152,7 +152,7 @@ class Notification
     private function getNotificationDataRules()
     {
         return [
-            'required' => ['included_segments', 'app_id'],
+            'required' => ['app_id'],
             'defined' => [
                 'app_id' => 'string',
                 'app_ids' => 'array',


### PR DESCRIPTION
Based on OneSignal API documentation, `included_segments` is not required. 

JSON example:
```
{
  "app_id": "5eb5a37e-b458-11e3-ac11-000c2940e62c",
  "include_player_ids": ["6392d91a-b206-4b7b-a620-cd68e32c3a76","76ece62b-bcfe-468c-8a78-839aeaa8c5fa","8e0f21fa-9a5a-4ae7-a9a6-ca1f24294b86"],
  "data": {"foo": "bar"},
  "contents": {"en": "English Message"}
}
```