### PR TITLE
add channel ID options

### DIFF
--- a/src/API/Notification.php
+++ b/src/API/Notification.php
@@ -226,6 +226,8 @@ class Notification
                 'isWP_WNS' => 'bool',
                 'isAdm' => 'bool',
                 'isChrome' => 'bool',
+                'android_channel_id' => 'string',
+                'huawei_channel_id' => 'string',
             ],
         ];
     }


### PR DESCRIPTION
many parameters have been deprecated in favor of using channel ids instead.  Channel ID refers to a notification category in OneSignal (https://documentation.onesignal.com/docs/android-notification-categories)